### PR TITLE
dont execute tests if CICD_ATF_ENABLED is false

### DIFF
--- a/lib/prototype/server/build.js
+++ b/lib/prototype/server/build.js
@@ -87,6 +87,17 @@ module.exports = function () {
                     throw Error('there is already a pending pull request for this update-set');
                 });
             }).then(() => {
+                
+                if (run.build.test.enabled == true) {
+                    /* if the test configuration is enabled (in build-config.json)
+                        disable in case ATF is disabled on the server (via process.env.CICD_ATF_ENABLED)
+                    */
+                    if (run.config.atf.enabled == false){
+                        console.log("Build Config: disable ATF test execution. (run.config.atf.enabled == false)")
+                        run.build.test.enabled = false;
+                    }
+                }
+
                 return res.json(run.build);
             });
         }).catch((e) => {

--- a/lib/test-wrapper.js
+++ b/lib/test-wrapper.js
@@ -25,10 +25,15 @@ module.exports.run = function ({ commitId, on }, logger = console) {
             testOnHostName = run.config.host.name.toLowerCase().replace(/\/$/, "");
         }
 
+        // exit in case ATF is disabled
+        if (run.config.atf.enabled == false) {
+            throw Error(`Execution of test disabled. Change CICD_ATF_ENABLED and re-build app.`);
+        }
+
         // ensure test can not run on production
-        if (!get(['config', 'master', 'host', 'name'], run) && process.env.CICD_ATF_RUN_ON_PRODUCTION == 'false') {
+        if (get(['config', 'master', 'host', 'name'], run) && process.env.CICD_ATF_RUN_ON_PRODUCTION == 'false') {
             if (run.config.master.host.name == testOnHostName)
-                throw Error(`Execution of test on master not allowed. Change CICD_ATF_RUN_ON_PRODUCTION`);
+                throw Error(`Execution of test on master not allowed. Change CICD_ATF_RUN_ON_PRODUCTION and re-build app.`);
         }
 
         return self.db.test.findOne({


### PR DESCRIPTION
CICD_ATF_ENABLED=false by mistake was still causing the server to run the ATF test cases.