### PR TITLE
Fix/2605 atf lookup

### DIFF
--- a/lib/cicd.js
+++ b/lib/cicd.js
@@ -902,10 +902,10 @@ const CICD = (function () {
         const client = self.getClient(config);
 
         const param = {
-            tableName: 'sys_metadata',
+            tableName: 'sys_atf_test_suite',
             options: {
                 qs: {
-                    sysparm_query: `sys_class_name=sys_atf_test_suite^sys_scope=${config.application.id}`,
+                    sysparm_query: `active=true^sys_scope=${config.application.id}`,
                     sysparm_fields: 'sys_id, sys_class_name'
                 }
             }
@@ -927,10 +927,10 @@ const CICD = (function () {
         const client = self.getClient(config);
 
         const param = {
-            tableName: 'sys_metadata',
+            tableName: 'sys_atf_test',
             options: {
                 qs: {
-                    sysparm_query: `sys_class_name=sys_atf_test^sys_scope=${config.application.id}`,
+                    sysparm_query: `active=true^sys_scope=${config.application.id}`,
                     sysparm_fields: 'sys_id, sys_class_name'
                 }
             }
@@ -962,20 +962,34 @@ const CICD = (function () {
             if (sysIds.length === 0)
                 return [];
 
-            const param = {
-                tableName: 'sys_atf_step',
-                options: {
-                    qs: {
-                        sysparm_query: `sys_idIN${sysIds.join(',')}`,
-                        sysparm_fields: 'sys_id, test'
+
+            const arrayChunks = (array, chunkSize) => Array(Math.ceil(array.length / chunkSize)).fill().map((_, index) => index * chunkSize).map((begin) => array.slice(begin, begin + chunkSize));
+            const chunks = arrayChunks(sysIds, 25);
+
+            if (chunks.length > 1)
+                console.log(`getTestsFromTestStep : split query into ${chunks.length} chunks`);
+
+            return Promise.mapSeries(chunks, (chunk, index) => {
+                if (chunks.length > 1)
+                    console.log(`\tchunk ${index + 1} with ${chunk.length} sys_id's`);
+
+                const param = {
+                    tableName: 'sys_atf_step',
+                    options: {
+                        qs: {
+                            sysparm_query: `test.active=true^active=true^sys_idIN${chunk.join(',')}`,
+                            sysparm_fields: 'sys_id, test'
+                        }
                     }
-                }
-            };
-            return client.getFilesFromTable(param).map(function (atfStep) {
-                return {
-                    className: 'sys_atf_test',
-                    sysId: atfStep.test
                 };
+                return client.getFilesFromTable(param).map(function (atfStep) {
+                    return {
+                        className: 'sys_atf_test',
+                        sysId: atfStep.test
+                    }
+                });
+            }).then((filesPerChunks) => {
+                return filesPerChunks.flat(1);
             });
         })
     };
@@ -1044,7 +1058,7 @@ const CICD = (function () {
 
                 console.log(`\t${className} (${allfilesByClass.length} records in ${chunks.length} chunks)`);
 
-                // split in blocks of 25 files to reduce the URL lengt later in processFiles()
+                // split in blocks of 25 files to reduce the URL length later in processFiles()
                 return Promise.each(chunks, (files) => {
                     //console.log(`\t#${index + 1}`);
                     return self.processFiles({ remote, project, config }, className, files).then((filesUpdated) => {

--- a/lib/modules/test-project.js
+++ b/lib/modules/test-project.js
@@ -28,6 +28,8 @@ module.exports = function ({ id, commitId, on }, logger = console, { host }) {
         return action(value).then(promiseFor.bind(null, condition, action));
     });
 
+    const arrayChunks = (array, chunkSize) => Array(Math.ceil(array.length / chunkSize)).fill().map((_, index) => index * chunkSize).map((begin) => array.slice(begin, begin + chunkSize));
+
     const step = (message, error) => {
         return self.addStep(logger, config, `${path.basename(__filename).split('.')[0]} : ${message}`, error);
     };
@@ -279,8 +281,22 @@ module.exports = function ({ id, commitId, on }, logger = console, { host }) {
 
         // as ATF run in sequence in Service-Now
         return Promise.try(() => {
-            if (normalBuildRun)
-                return run.build.test.suites;
+            if (normalBuildRun) {
+                // validate if test-suites still active
+                const suites = run.build.test.suites || [];
+                const chunks = arrayChunks(suites, 25);
+                return Promise.mapSeries(chunks, (chunk, index) => {
+                    const param = {
+                        tableName: 'sys_atf_test_suite',
+                        options: { qs: { sysparm_query: `active=true^sys_idIN${chunk.join(',')}`, sysparm_fields: 'sys_id' } }
+                    };
+                    return client.getFilesFromTable(param).map(function (file) {
+                        return file.sys_id
+                    });
+                }).then((filesPerChunks) => {
+                    return filesPerChunks.flat(1);
+                });
+            }
             return self.getApplicationTestSuites(config).map((suite) => {
                 return suite.sysId;
             });
@@ -288,10 +304,25 @@ module.exports = function ({ id, commitId, on }, logger = console, { host }) {
             test.suites = suites || [];
             if (test.suites.length)
                 return step(`Suites to be executed ${suites.join(',')}`);
+
         }).then(() => {
             return Promise.try(() => {
-                if (normalBuildRun)
-                    return run.build.test.tests;
+                if (normalBuildRun) {
+                    // validate if tests still active
+                    const tests = run.build.test.tests || [];
+                    const chunks = arrayChunks(tests, 25);
+                    return Promise.mapSeries(chunks, (chunk, index) => {
+                        const param = {
+                            tableName: 'sys_atf_test',
+                            options: { qs: { sysparm_query: `active=true^sys_idIN${chunk.join(',')}`, sysparm_fields: 'sys_id' } }
+                        };
+                        return client.getFilesFromTable(param).map(function (file) {
+                            return file.sys_id
+                        });
+                    }).then((filesPerChunks) => {
+                        return filesPerChunks.flat(1);
+                    });
+                }
                 return self.getApplicationTests(config).then((tests) => {
 
                     if (tests && tests.length) { // get all tests which are assigned to a Suite
@@ -317,6 +348,7 @@ module.exports = function ({ id, commitId, on }, logger = console, { host }) {
             test.tests = tests || [];
             if (test.tests.length)
                 return step(`Tests to be executed ${tests.join(',')}`);
+                
         }).then(() => {
             if (!normalBuildRun) {
                 return slack.message(`*${run.config.application.name} › ${run.config.updateSet.name} › #${run.sequence}*\nATF Execution\n\nGoing to execute ${test.suites.length > 0 ? `${test.suites.length} suite${test.suites.length > 1 ? 's' : ''}` : 'NO suite'} and ${test.tests.length > 0 ? `${test.tests.length} test${test.tests.length > 1 ? 's' : ''}` : 'NO tests'} for update set <${self.link(config.host.name, `/sys_update_set.do?sys_id=${config.updateSet.sys_id}`)}|${config.updateSet.name}> on <${config.host.name}|${config.host.name}>\n\n<${run.config.application.docUri}|details>`);


### PR DESCRIPTION
only execute ATF test cases if active on the host (state in service now overrules status in update set)
split request int chunks of 25 sys_id to avoid URL length exceptions
