### PR TITLE
Dev/individual preflight

### DIFF
--- a/example.env
+++ b/example.env
@@ -96,8 +96,17 @@ CICD_EB_HOST_PORT=4443
 ## # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # CODE EXPORT
 #
-# Run update set collision detection at first
+# Run update set collision detection at first - aka PREFLIGHT
 CICD_CONFLICT_DETECTION_ENABLED=true
+
+# set this to 'true' to only allow to run conflict detection as specified below
+CICD_STRICT_CONFLICT_DETECTION=false
+
+# default conflict detection host
+CICD_CONFLICT_DETECTION_TARGET=''
+# conflict detection target definition
+CICD_CONFLICT_DETECTION_TARGET_DEVINSTANCE=testcompany.service-now.com
+
 
 # CICD API Prefix. If you have your own version of the 'CICD Integration' application in ServiceNow, name here the scope prefix
 CICD_APP_PREFIX=devops

--- a/lib/cicd.js
+++ b/lib/cicd.js
@@ -423,8 +423,8 @@ const CICD = (function () {
         if (!config || !config.host)
             return null;
 
-        const m = config.host.name.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-        const varName = `CICD_CI${((m) ? `_${m[1].toUpperCase()}` : '')}_USER`;
+        const subDomain = self.getSubdomain(config.host.name, false)
+        const varName = `CICD_CI${((subDomain) ? `_${subDomain.toUpperCase()}` : '')}_USER`;
 
         const username = process.env[`${varName}_NAME`] || process.env.CICD_CI_USER_NAME;
         const password = process.env[`${varName}_PASSWORD`] || process.env.CICD_CI_USER_PASSWORD;
@@ -1330,6 +1330,20 @@ const CICD = (function () {
      */
     CICD.prototype.start = require('./prototype/start');
 
+    /**
+     * get the sub domain from the host
+     * 
+     * @param {*} host 
+     * @param {*} fallback if the regex does not match return this as fallback - in stead of the host parameter
+     */
+    CICD.prototype.getSubdomain = function (host, fallback) {
+        if(!host)
+            return fallback !== undefined ? fallback : host;
+            
+        const m = host.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
+        // fallback to full source host name
+        return (m) ? m[1] : fallback !== undefined ? fallback : host;
+    };
 
     return CICD;
 })();

--- a/lib/cicdInt.js
+++ b/lib/cicdInt.js
@@ -283,6 +283,9 @@ CICDInt.prototype = {
                 },
                 target: {
                     name: null,
+                },
+                preflight: {
+                    name: null,
                 }
             }, body);
 
@@ -318,6 +321,13 @@ CICDInt.prototype = {
                 options.deploy = {
                     host: {
                         name: req.target.name
+                    }
+                };
+            }
+            if (req.preflight.name) {
+                options.preflight = {
+                    host: {
+                        name: req.preflight.name
                     }
                 };
             }

--- a/lib/deployment-wrapper.js
+++ b/lib/deployment-wrapper.js
@@ -100,8 +100,7 @@ module.exports.run = function ({ commitId, from, to, deploy, git }, logger = con
                 return to;
             } else if (process.env.CICD_CD_STRICT_DEPLOYMENT == 'true' || configTarget === null) {
                 // deploy ony to the configured target environments
-                const m = sourceHostName.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-                const sourceInstanceName = (m) ? m[1] : sourceHostName;
+                const sourceInstanceName = self.getSubdomain(sourceHostName);
                 return process.env[`CICD_CD_DEPLOYMENT_TARGET_${sourceInstanceName.toUpperCase()}`] || process.env.CICD_CD_DEPLOYMENT_TARGET || '';
             } else {
                 return configTarget;

--- a/lib/modules/deploy-update-set.js
+++ b/lib/modules/deploy-update-set.js
@@ -87,11 +87,9 @@ module.exports = function ({ id = uuidv4().toLowerCase(), commitId, from, to, de
 
         normalBuildRun = (config.host.name == sourceHostName && config.deploy.host.name == targetHostName);
 
-        const m1 = sourceHostName.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-        sourceInstanceName = (m1) ? m1[1] : sourceHostName;
+        sourceInstanceName = self.getSubdomain(sourceHostName);
 
-        const m2 = targetHostName.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-        targetInstanceName = (m2) ? m2[1] : targetHostName;
+        targetInstanceName = self.getSubdomain(targetHostName);
 
         return self.db.deployment.findOne({
             _id: id

--- a/lib/modules/project-setup.js
+++ b/lib/modules/project-setup.js
@@ -501,7 +501,7 @@ module.exports = function (options = {}, logger = console, { host }) {
         config.deploy.host.name = config.deploy.host.name.toLowerCase().replace(/\/$/, "");
 
     // get the sub domain from the domain
-    const sourceInstanceName = self.self.getSubdomain(config.host.name);
+    const sourceInstanceName = self.getSubdomain(config.host.name);
 
     if (process.env.CICD_CD_STRICT_DEPLOYMENT == 'true') {
         const targetHostName = process.env[`CICD_CD_DEPLOYMENT_TARGET_${sourceInstanceName.toUpperCase()}`] || process.env.CICD_CD_DEPLOYMENT_TARGET

--- a/lib/modules/project-setup.js
+++ b/lib/modules/project-setup.js
@@ -416,7 +416,7 @@ module.exports = function (options = {}, logger = console, { host }) {
             applicationId: null,
             usId: null,
             runId: null,
-            collisionDetection: (process.env.CICD_CONFLICT_DETECTION_ENABLED == 'true') ? true : false
+            collisionDetection: null
         },
         atf: {
             updateSetOnly: false,
@@ -458,6 +458,11 @@ module.exports = function (options = {}, logger = console, { host }) {
             onBuildPass: false,
             onPullRequestResolve: false,
             enabled: false
+        },
+        preflight: {
+            host: {
+                name: null
+            }
         }
     }, options, {
         application: {
@@ -495,10 +500,10 @@ module.exports = function (options = {}, logger = console, { host }) {
     if (config.deploy.host.name)
         config.deploy.host.name = config.deploy.host.name.toLowerCase().replace(/\/$/, "");
 
-    if (process.env.CICD_CD_STRICT_DEPLOYMENT == 'true') {
-        const m = config.host.name.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-        const sourceInstanceName = (m) ? m[1] : config.host.name;
+    // get the sub domain from the domain
+    const sourceInstanceName = self.self.getSubdomain(config.host.name);
 
+    if (process.env.CICD_CD_STRICT_DEPLOYMENT == 'true') {
         const targetHostName = process.env[`CICD_CD_DEPLOYMENT_TARGET_${sourceInstanceName.toUpperCase()}`] || process.env.CICD_CD_DEPLOYMENT_TARGET
         if (targetHostName) {
             config.deploy.host = {
@@ -508,12 +513,29 @@ module.exports = function (options = {}, logger = console, { host }) {
     }
 
     if (process.env.CICD_GIT_STRICT_MASTER == 'true') {
-        const m = config.host.name.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-        const sourceInstanceName = (m) ? m[1] : config.host.name;
-
         const targetHostName = process.env[`CICD_GIT_MASTER_SOURCE_${sourceInstanceName.toUpperCase()}`] || process.env.CICD_GIT_MASTER_SOURCE
         if (targetHostName) {
             config.master.host = {
+                name: `https://${targetHostName}`
+            };
+        }
+    }
+
+    if(config.preflight.host.name){
+        // if there is a preflight host name, enable collisionDetection
+        config.build.collisionDetection = true;
+        config.preflight.host.name = config.preflight.host.name.toLowerCase().replace(/\/$/, "");
+
+    } else if(process.env.CICD_CONFLICT_DETECTION_ENABLED == 'true'){
+        config.build.collisionDetection = true;
+        // if preflight is enabled but no preflight host is specified use the deploy host name
+        config.preflight.host.name = config.deploy.host.name;
+    }
+
+    if (config.build.collisionDetection && process.env.CICD_STRICT_CONFLICT_DETECTION == 'true') {
+        const targetHostName = process.env[`CICD_CONFLICT_DETECTION_TARGET_${sourceInstanceName.toUpperCase()}`] || process.env.CICD_CONFLICT_DETECTION_TARGET
+        if (targetHostName) {
+            config.preflight.host = {
                 name: `https://${targetHostName}`
             };
         }

--- a/lib/modules/run-collision-detection.js
+++ b/lib/modules/run-collision-detection.js
@@ -51,28 +51,15 @@ module.exports = function (runId, logger = console, { host }) {
 
             sourceHostName = (!sourceHostName.startsWith('https://')) ? `https://${sourceHostName}` : sourceHostName;
 
-            let targetHostName = (() => {
-                const configTarget = (run.config.deploy && run.config.deploy.host && run.config.deploy.host.name) ? run.config.deploy.host.name : null;
-                if (process.env.CICD_CD_STRICT_DEPLOYMENT == 'true' || configTarget === null) {
-                    // deploy ony to the configured target environments
-                    const m = sourceHostName.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-                    const sourceInstanceName = (m) ? m[1] : sourceHostName;
-                    return process.env[`CICD_CD_DEPLOYMENT_TARGET_${sourceInstanceName.toUpperCase()}`] || process.env.CICD_CD_DEPLOYMENT_TARGET || '';
-                } else {
-                    return configTarget;
-                }
-            })().toLowerCase().replace(/\/$/, "");
-
+            let targetHostName = (config.preflight.host.name || '').toLowerCase().replace(/\/$/, "");
             if (!targetHostName)
                 throw Error('RunCollisionDetection: No target host specified for preflight checks!');
 
             targetHostName = (!targetHostName.startsWith('https://')) ? `https://${targetHostName}` : targetHostName;
 
-            const m1 = sourceHostName.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-            const sourceInstanceName = (m1) ? m1[1] : sourceHostName;
+            const sourceInstanceName = self.getSubdomain(sourceHostName);
 
-            const m2 = targetHostName.match(/(?:http[s]?:\/\/)([^\.]*)([^:\/]*)/i);
-            const targetInstanceName = (m2) ? m2[1] : targetHostName;
+            const targetInstanceName = self.getSubdomain(targetHostName);
 
 
             const client = self.getClient({ host: { name: sourceHostName } });

--- a/lib/snClient.js
+++ b/lib/snClient.js
@@ -336,9 +336,26 @@ module.exports = function ({
             return Promise.all([checkSourceVersion, checkTargetVersion]);
 
         }).then(() => {
+
+            if(conflictResolutions){
+                const conflicts = Object.keys(conflictResolutions).map((conflict)=>{
+                    return `${conflictResolutions[conflict].status.toUpperCase()} '${conflict}'`; 
+                }).join(', ');
+                if(conflicts.trim())
+                    console.log(`Auto resolve: ${conflicts}`);
+            }
+            if(process.env.CICD_CD_DEPLOY_ALWAYS_SKIP_CONFLICTS){
+                console.log(`Auto skip: ${process.env.CICD_CD_DEPLOY_ALWAYS_SKIP_CONFLICTS}`);
+            }
+            if(process.env.CICD_CD_DEPLOY_ALWAYS_IGNORE_CONFLICTS){
+                console.log(`Auto ignore: ${process.env.CICD_CD_DEPLOY_ALWAYS_IGNORE_CONFLICTS}`);
+            }
+            
+            console.log(`Auto ignore data loss: ${Boolean(process.env.CICD_CD_DEPLOY_ALWAYS_IGNORE_DATA_LOSS === 'true')}`);
+
             return promiseFor((nextOptions) => Boolean(nextOptions),
                 (options) => {
-                    console.log('Request: ', options.url);
+                    console.log('Request: ', options.url);                    
                     //console.dir(options, { colors: true, depth: null });
 
                     // create a new copy of the defaults client


### PR DESCRIPTION
Allow to pass a preflight host name instead of using the deployment target by default.
New .env vars are following the same pattern as for deployment target