### PR TITLE
ensure run.config.application is in place

### DIFF
--- a/lib/cicd.js
+++ b/lib/cicd.js
@@ -276,9 +276,11 @@ const CICD = (function () {
             console.log('INIT\t', 'migrate run.mergedDeployment & run.forcedDeployment');
             return self.db.run.find({ 'config.mergedDeployment': { $exists: false } }).then((result) => {
                 return Promise.each(result, (run) => {
-                    run.config.mergedDeployment = run.config.application.mergedDeployment;
-                    run.config.forcedDeployment = run.config.application.forcedDeployment;
-                    return self.db.run.update(run);
+                    if(run.config && run.config.application){
+                        run.config.mergedDeployment = run.config.application.mergedDeployment;
+                        run.config.forcedDeployment = run.config.application.forcedDeployment;
+                        return self.db.run.update(run);
+                    }
                 });
             });
         }).then(() => {


### PR DESCRIPTION
check for object correctness to avoid TypeError: Cannot read property 'application' of null
