### PR TITLE
use CICD_EMAIL_ADMINS_CC to send email to CC

### DIFF
--- a/example.env
+++ b/example.env
@@ -154,9 +154,10 @@ CICD_EMAIL_USER_PASSWORD=
 CICD_EMAIL_SECURE=false
 # senders address
 CICD_EMAIL_FROM=noreply@company.com
-# admin email address(es) to inform on deployment issues
+# additional admin email address(es) to inform on deployment issues (email:to) - email to developer is always sent
 CICD_EMAIL_ADMINS=
-
+# admin email address(es) to inform on deployment issues (email:cc)
+CICD_EMAIL_ADMINS_CC=
 
 ## # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # GIT 

--- a/lib/cicd.js
+++ b/lib/cicd.js
@@ -84,7 +84,8 @@ const CICD = (function () {
             },
             worker: () => {
                 return self.worker();
-            }
+            },
+            self : (process.env.TESTING) ? self : undefined
         };
     };
 
@@ -678,7 +679,7 @@ const CICD = (function () {
             return nodemailer.createTransport(options);
         },
 
-        text: function (recipient, subject, message) {
+        text: function ({recipient, cc, subject, message}) {
             return Promise.try(() => {
                 if (process.env.CICD_EMAIL_ENABLED !== 'true') {
                     console.warn('Email notification is disabled. Following message was not sent:', recipient, subject, message)
@@ -687,6 +688,7 @@ const CICD = (function () {
                 return this.getTransporter().sendMail({
                     from: process.env.CICD_EMAIL_FROM,
                     to: recipient,
+                    cc,
                     subject: subject,
                     html: message
                 }).catch((e) => {
@@ -696,7 +698,7 @@ const CICD = (function () {
         },
 
 
-        onBuildFailure: function ({ recipient, subject, data: { sequence, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, docUri } }) {
+        onBuildFailure: function ({ recipient, cc, subject, data: { sequence, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, docUri } }) {
 
             subject = subject || `[CICD Build Warning] : Build for '${sourceUpdateSetName} › #${sequence}' failed`;
             const message = `<h2><font color="red">Build failed</font></h2>
@@ -705,31 +707,36 @@ const CICD = (function () {
                         Build results can be found <a href="${docUri}">here</a>
                         </p>`;
 
-            return this.text(recipient, subject, message);
+            return this.text({
+                recipient: ((recipient) ? Array.isArray(recipient) ? recipient : [recipient] : []).concat((process.env.CICD_EMAIL_ADMINS || '').split(',')),
+                cc: ((cc) ? Array.isArray(cc) ? cc : [cc] : []).concat((process.env.CICD_EMAIL_ADMINS_CC || '').split(',')),
+                subject,
+                message
+            });
         },
 
-        onPreviewConflicts: function ({ recipient, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, previewProblems, dataLossWarnings } }) {
+        onPreviewConflicts: function ({ recipient, cc, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, previewProblems, dataLossWarnings } }) {
 
             subject = subject || `PREFLIGHT CONFLICTS - Update Set is causing conflicts : Preview of '${sourceUpdateSetName} › #${sequence}' requires manual interaction`;
             const lead = `<h2><font color="orange">Preview of '${sourceUpdateSetName} › #${sequence}' requires manual interaction.</font></h2>
                 <p>The <b>'conflict detection'</b> step on target ${targetHostName} failed and requires to be resolved manually.</p>
                 <p><b>Please open the <a href="${remoteUpdateSetUrl}">Preview Update Set</a> and resolve all conflicts to proceed with this CICD run.</b></p>`;
 
-            return this.onDeploymentConflicts({ recipient, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, previewProblems, dataLossWarnings } }, lead);
+            return this.onDeploymentConflicts({ recipient, cc, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, previewProblems, dataLossWarnings } }, lead);
 
         },
 
-        onPreviewFailure: function ({ recipient, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }) {
+        onPreviewFailure: function ({ recipient, cc, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }) {
 
             subject = subject || `[CICD Conflict Detection Error] : Preview of '${sourceUpdateSetName} › #${sequence}' failed`;
             const lead = `<h2><font color="red">Conflicts in Update Set '${sourceUpdateSetName}'</font></h2>
             <p>The <b>'conflict detection'</b> step on target ${targetHostName} failed!</p>`;
 
-            return this.onDeploymentFailure({ recipient, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }, lead);
+            return this.onDeploymentFailure({ recipient, cc, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }, lead);
         },
 
 
-        onDeploymentConflicts: function ({ recipient, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, previewProblems, dataLossWarnings } }, lead) {
+        onDeploymentConflicts: function ({ recipient, cc, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, previewProblems, dataLossWarnings } }, lead) {
 
             subject = subject || `DEPLOYMENT CONFLICTS - Update Set is causing conflicts: Deployment of '${sourceUpdateSetName} › #${sequence}' requires manual interaction`;
             let message = lead || `<h2><font color="red">Deployment Conflicts in Update Set '${sourceUpdateSetName} › #${sequence}'</font></h2>
@@ -771,10 +778,15 @@ const CICD = (function () {
                 }), '</table></p>').join('');
             }
 
-            return this.text([recipient].concat((process.env.CICD_EMAIL_ADMINS || '').split(',')).join(','), subject, message);
+            return this.text({
+                recipient: ((recipient) ? Array.isArray(recipient) ? recipient : [recipient] : []).concat((process.env.CICD_EMAIL_ADMINS || '').split(',')),
+                cc: ((cc) ? Array.isArray(cc) ? cc : [cc] : []).concat((process.env.CICD_EMAIL_ADMINS_CC || '').split(',')),
+                subject,
+                message
+            });
         },
 
-        onDeploymentHasMissingRecords: function ({ recipient, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, missingRecords } }) {
+        onDeploymentHasMissingRecords: function ({ recipient, cc, subject, data: { sequence, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName, remoteUpdateSetID, remoteUpdateSetUrl, missingRecords } }) {
 
             subject = subject || `DEPLOYMENT - Completed with missing references! Deployment of '${sourceUpdateSetName} › #${sequence}' requires manual interaction`;
 
@@ -786,10 +798,10 @@ const CICD = (function () {
                 return `<li><a href="${missingRecords[updateName].link}">${updateName}</a> ${missingRecords[updateName].description}</li>`;
             }).join(''), '</ul>');
 
-            return this.onDeploymentFailure({ recipient, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }, lead);
+            return this.onDeploymentFailure({ recipient, cc, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }, lead);
         },
 
-        onDeploymentFailure: function ({ recipient, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }, lead) {
+        onDeploymentFailure: function ({ recipient, cc, subject, data: { sequence, errorName, errorMessage, sourceHostName, sourceUpdateSetName, sourceUpdateSetID, sourceUpdateSetUrl, targetHostName } }, lead) {
 
             subject = subject || `[CICD Deployment Error] : Deployment of '${sourceUpdateSetName} › #${sequence}' failed`;
             let message = lead || `<h2><font color="red">The update set deployment on target ${targetHostName} failed!</font></h2>`;
@@ -804,7 +816,12 @@ const CICD = (function () {
                 </p>`;
 
 
-            return this.text([recipient].concat((process.env.CICD_EMAIL_ADMINS || '').split(',')).join(','), subject, message);
+            return this.text({
+                recipient: ((recipient) ? Array.isArray(recipient) ? recipient : [recipient] : []).concat((process.env.CICD_EMAIL_ADMINS || '').split(',')),
+                cc: ((cc) ? Array.isArray(cc) ? cc : [cc] : []).concat((process.env.CICD_EMAIL_ADMINS_CC || '').split(',')),
+                subject,
+                message
+            });
         }
     };
 

--- a/test/email.js
+++ b/test/email.js
@@ -1,0 +1,24 @@
+const path = require('path');
+require('dotenv').config({
+    path: path.resolve(__dirname, 'mocha', '.env')
+});
+require('dotenv').config();
+
+process.env.TESTING = 'true';
+
+var CICD = require('../lib/cicd');
+
+var cicd = new CICD();
+
+cicd.self.email.onBuildFailure({
+    recipient: process.env.TEST_EMAIL_TO,
+    cc: process.env.TEST_EMAIL_CC,
+    subject: 'Test Mail',
+    data: {
+        sequence: 1,
+        sourceUpdateSetName: 'sourceUpdateSetName',
+        sourceUpdateSetID: 'sourceUpdateSetID',
+        sourceUpdateSetUrl: 'sourceUpdateSetUrl',
+        docUri: 'docUri'
+    }
+});


### PR DESCRIPTION
to underline the importance of emails sent out due to deployment issues as conflicts the additional admin recipients can be put to the CC field. 

So the email is sent like:
 - to : **developer**, CICD_EMAIL_ADMINS [optional]
 - cc: CICD_EMAIL_ADMINS_CC [optional]