### PR TITLE
use run.mergedTs as ts for deployment

### DIFF
--- a/lib/deployment-wrapper.js
+++ b/lib/deployment-wrapper.js
@@ -317,13 +317,13 @@ module.exports.run = function ({ commitId, from, to, deploy, git = (process.env.
                     usId: run.usId,
                     appId: run.appId,
                     commitId: run.commitId,
+                    ts: run.mergedTs,
                     sysId,
                     scopeName,
                     groupId,
                     scope: deployments.scopes[scopeName],
                     baselineCommitId: deployments.baselineCommitId,
                     baselineTs: deployments.baselineTs,
-                    ts: Date.now(),
                     fix: config.fixDeployment || false
                 });
             });


### PR DESCRIPTION
If deployments are triggered via remote build tool (embedded deployment is disabled) it can happen that scopes are missed out.
Using run.mergedTs along with run.commitId solves this issue.