### PR TITLE
try/catch merge Abort if cause is not merge issue (and use await)

### DIFF
--- a/lib/modules/export-update-set.js
+++ b/lib/modules/export-update-set.js
@@ -115,7 +115,7 @@ module.exports = function (runId, logger = console, { host }) {
                         return step('GIT merge failed. Abort now.');
                     }).then(async () => {
                         try {
-                            return git.mergeAbort();
+                            await git.mergeAbort();
                         } catch (e) {
                             logger.warn("MergeAbort failed", e)
                         }


### PR DESCRIPTION
avoid to fail if there is no merge issue (There is no merge to abort)