### PR TITLE
use app ID for exclusive job ID

### DIFF
--- a/lib/prototype/server/deploy.js
+++ b/lib/prototype/server/deploy.js
@@ -39,28 +39,19 @@ module.exports = function () {
 
             //console.log('New Deployment Request', { commitId, from, to, deploy, git });
 
-            const job = await new ExeJob({ name: 'deploy', background: true, exclusiveId: `deploy-${commitId}`, description: `Deploy ${commitId}` },
+            const run = await self.db.run.findOne({
+                commitId
+            });
+
+            const exId = run ? run.appId : commitId;
+
+            const job = await new ExeJob({ name: 'deploy', background: true, exclusiveId: `deploy-${exId}`, description: `Deploy ${commitId}` },
                 { commitId, from, to, deploy, git });
             console.log(`Deployment job started. JobId: ${job._id}`);
 
             console.log('redirect to ', `${req.baseUrl}${DEPLOY_EXECUTE}/job/${job._id}`);
             res.setHeader('Location', `${req.baseUrl}${DEPLOY_EXECUTE}/job/${job._id}`);
             res.sendStatus(202); // job created, come back to url 
-
-            /*
-            const deploymentWrapper = require('../../deployment-wrapper');
-            return deploymentWrapper.run.call(self, { commitId, from, to, deploy, git }).then((deployments) => {
-    
-                const ids = deployments.map((deployment) => (deployment.id)).join(',');
-    
-                console.log('redirect to ', `/deploy${DEPLOY_EXECUTE}/${commitId}/${ids}`);
-                res.setHeader('Location', `/deploy${DEPLOY_EXECUTE}/${commitId}/${ids}`);
-                res.sendStatus(202); // job created, come back to url    
-            }).catch((e) => {
-                console.error(e.message);
-                return res.status(400).send(e.message);
-            });
-            */
 
         } catch (e) {
             console.error(__filename, 'error:', req.originalUrl, e);


### PR DESCRIPTION
Use the appId as the unique identifier for the deployment. This ensures that there is only one active deployment per application at any given time.